### PR TITLE
Defect 002 - Menu Directory service enters non-veg for all dishes in DB

### DIFF
--- a/src/main/java/com/project/tejas/menuDirectory/dto/MenuItemDTO.java
+++ b/src/main/java/com/project/tejas/menuDirectory/dto/MenuItemDTO.java
@@ -11,7 +11,7 @@ public class MenuItemDTO {
     private int id;
     private String dishName;
     private String dishDescription;
-    private boolean isVeg;
+    private Boolean isVeg;
     private Long price;
     private Integer restaurantId;
     private Integer quantity;

--- a/src/main/java/com/project/tejas/menuDirectory/entity/MenuItem.java
+++ b/src/main/java/com/project/tejas/menuDirectory/entity/MenuItem.java
@@ -19,7 +19,7 @@ public class MenuItem {
     private int id;
     private String dishName;
     private String dishDescription;
-    private boolean isVeg;
+    private Boolean isVeg;
     private Long price;
     private Integer restaurantId;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,16 @@
 server:
   port: 9092
 
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+
 spring:
   profiles:
     active: dev
   application:
-    name: FOOD-CATALOGUE-SERVICE
+    name: MENU-DIRECTORY-SERVICE
   datasource:
     url: jdbc:mysql://localhost:3306/menudirectorydb
     username: root


### PR DESCRIPTION
Defect 002 - Menu Directory service enters non-veg for all dishes in database

Description - Adding new food item - Database enters the "isVeg" column as 0 (false) for all entries irrespective of what was sent in the Postman post request

Fixes - The issue was happeningdue to Mapstruct's inability to detect boolean values when we provide variables of primitive boolean type in both the entity class and the DTO class. Hence we had to change the data type of isVeg variable to the wrapper class (Boolean). This is working with MapStruct as expected.

Files changed - 
MenuItem.java
MenuItemDTO.java
application.yml